### PR TITLE
Fix defaulting in `Element.renderMarkup()`

### DIFF
--- a/src/joint.dia.element.js
+++ b/src/joint.dia.element.js
@@ -562,7 +562,7 @@ joint.dia.ElementView = joint.dia.CellView.extend({
     // default markup is not desirable.
     renderMarkup: function() {
 
-        var markup = this.model.markup || this.model.get('markup');
+        var markup = this.model.get('markup') || this.model.markup;
 
         if (markup) {
 


### PR DESCRIPTION
The code doesn't match the comment. It should try to get "markup" from the model first and fallback to the prototype.